### PR TITLE
Refactor NinjectValidatorFactory

### DIFF
--- a/src/Ninject.Web.Mvc.FluentValidation/NinjectValidatorFactory.cs
+++ b/src/Ninject.Web.Mvc.FluentValidation/NinjectValidatorFactory.cs
@@ -1,47 +1,38 @@
 ﻿using System;
-using System.Collections.Generic;
 using FluentValidation;
-using Ninject.Planning.Bindings;
+using System.Linq;
 
 namespace Ninject.Web.Mvc.FluentValidation
 {
-   /// <summary>
-   /// Validation factory that uses ninject to create validators  
-   /// </summary>
-   public class NinjectValidatorFactory : ValidatorFactoryBase
-   {
-      /// <summary>
-      /// Initializes a new instance of the <see cref="NinjectValidatorFactory"/> class.
-      /// </summary>
-      /// <param name="kernel">The kernel.</param>
-      public NinjectValidatorFactory( IKernel kernel )
-      {
-         Kernel = kernel;
-      }
+    /// <summary>
+    /// Validation factory that uses ninject to create validators  
+    /// </summary>
+    public class NinjectValidatorFactory : ValidatorFactoryBase
+    {
+        private readonly IKernel _kernel;
 
-      /// <summary>
-      /// Gets or sets the kernel.
-      /// </summary>
-      /// <value>The kernel.</value>
-      public IKernel Kernel
-      {
-         get;
-         set;
-      }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NinjectValidatorFactory"/> class.
+        /// </summary>
+        /// <param name="kernel">The kernel.</param>
+        public NinjectValidatorFactory(IKernel kernel)
+        {
+            _kernel = kernel;
+        }
 
-      /// <summary>
-      /// Creates an instance of a validator with the given type using ninject.
-      /// </summary>
-      /// <param name="validatorType">Type of the validator.</param>
-      /// <returns>The newly created validator</returns>
-      public override IValidator CreateInstance( Type validatorType )
-      {
-         if ( ((IList<IBinding>)Kernel.GetBindings(validatorType)).Count == 0 )
-         {
-            return null;
-         }
+        /// <summary>
+        /// Creates an instance of a validator with the given type using ninject.
+        /// </summary>
+        /// <param name="validatorType">Type of the validator.</param>
+        /// <returns>The newly created validator</returns>
+        public override IValidator CreateInstance(Type validatorType)
+        {
+            if (!_kernel.GetBindings(validatorType).Any())
+            {
+                return null;
+            }
 
-         return Kernel.Get( validatorType ) as IValidator;
-      }
-   }
+            return _kernel.Get(validatorType) as IValidator;
+        }
+    }
 }


### PR DESCRIPTION
- Hide the kernel without exposing it to public
- Use .Any() instead of casting it to IList
